### PR TITLE
fix: lets enable using the `helmboot secrets export`

### DIFF
--- a/templates/install.yaml
+++ b/templates/install.yaml
@@ -40,6 +40,18 @@ spec:
         - name: workdir
           mountPath: "/processed"
       {{- end }}
+      {{- if .Values.secrets.helmboot.enabled }}
+      - name: init-secrets
+        image: jenkinsxio/jenkins-x-installer:0.0.31
+        command:
+        - /bin/sh
+        args:
+        - -c
+        - "jxl helmboot secrets export -f /processed/secrets.yaml"
+        volumeMounts:
+        - name: workdir
+          mountPath: "/processed"
+      {{- end }}
       {{- if .Values.secrets.gsm.enabled }}
       - name: init-secrets
         image: jenkinsxio/jenkins-x-installer:0.0.27

--- a/values.yaml
+++ b/values.yaml
@@ -17,6 +17,8 @@ boot:
   versionsGitRef: master
 
 secrets:
+  helmboot:
+    enabled: true
   gsm:
     enabled: false
   env:


### PR DESCRIPTION
to mount secrets in the build pod via an init container